### PR TITLE
Improve invalid command check and add default description

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDeadlineCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.Set;
@@ -32,19 +33,20 @@ public class AddDeadlineCommandParser implements Parser<AddDeadlineCommand> {
     public AddDeadlineCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_PRIORITY,
-                        PREFIX_TASK_DATE, PREFIX_TAG);
+                        PREFIX_TASK_DATE, PREFIX_TASK_TIME, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE, PREFIX_TASK_DATE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_TASK_TIME)
+                || !arePrefixesPresent(argMultimap, PREFIX_TITLE, PREFIX_TASK_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddDeadlineCommand.MESSAGE_USAGE));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
-        Description description = ParserUtil.parseDescription("");
+        Description description = ParserUtil.parseDescription("No Description");
         if (arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION)) {
             description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         }
-        Priority priority = ParserUtil.parsePriority("");
+        Priority priority = ParserUtil.parsePriority("No Priority Assigned");
         if (arePrefixesPresent(argMultimap, PREFIX_PRIORITY)) {
             priority = ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get());
         }

--- a/src/main/java/seedu/address/logic/parser/AddDeadlineCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddDeadlineCommandParser.java
@@ -35,7 +35,7 @@ public class AddDeadlineCommandParser implements Parser<AddDeadlineCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_PRIORITY,
                         PREFIX_TASK_DATE, PREFIX_TASK_TIME, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TASK_TIME)
+        if (arePrefixesPresent(argMultimap, PREFIX_TASK_TIME)
                 || !arePrefixesPresent(argMultimap, PREFIX_TITLE, PREFIX_TASK_DATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddDeadlineCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -42,11 +42,11 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
-        Description description = ParserUtil.parseDescription("");
+        Description description = ParserUtil.parseDescription("No Description");
         if (arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION)) {
             description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         }
-        Priority priority = ParserUtil.parsePriority("");
+        Priority priority = ParserUtil.parsePriority("No Priority Assigned");
         if (arePrefixesPresent(argMultimap, PREFIX_PRIORITY)) {
             priority = ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get());
         }

--- a/src/main/java/seedu/address/logic/parser/AddTodoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTodoCommandParser.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.Set;
@@ -29,19 +31,22 @@ public class AddTodoCommandParser implements Parser<AddTodoCommand> {
      */
     public AddTodoCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_PRIORITY, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_PRIORITY,
+                        PREFIX_TASK_DATE, PREFIX_TASK_TIME, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE)
+        if (arePrefixesPresent(argMultimap, PREFIX_TASK_DATE)
+                || arePrefixesPresent(argMultimap, PREFIX_TASK_TIME)
+                || !arePrefixesPresent(argMultimap, PREFIX_TITLE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTodoCommand.MESSAGE_USAGE));
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
-        Description description = ParserUtil.parseDescription("");
+        Description description = ParserUtil.parseDescription("No Description");
         if (arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION)) {
             description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         }
-        Priority priority = ParserUtil.parsePriority("");
+        Priority priority = ParserUtil.parsePriority("No Priority Assigned");
         if (arePrefixesPresent(argMultimap, PREFIX_PRIORITY)) {
             priority = ParserUtil.parsePriority(argMultimap.getValue(PREFIX_PRIORITY).get());
         }

--- a/src/main/java/seedu/address/model/task/Description.java
+++ b/src/main/java/seedu/address/model/task/Description.java
@@ -15,7 +15,7 @@ public class Description {
      * The first character of the description must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = ".*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -11,7 +11,6 @@ public class Priority {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Priority level should be Low, Medium or High";
-    public static final String VALIDATION_STRING_PRIORITY_BLANK = "";
     public static final String VALIDATION_STRING_PRIORITY_NONE = "NO PRIORITY ASSIGNED";
     public static final String VALIDATION_STRING_PRIORITY_LOW = "LOW";
     public static final String VALIDATION_STRING_PRIORITY_MEDIUM = "MEDIUM";
@@ -28,7 +27,6 @@ public class Priority {
         requireNonNull(level);
         checkArgument(isValidPriority(level), MESSAGE_CONSTRAINTS);
         switch(level.toUpperCase()) {
-        case "":
         case"NO PRIORITY ASSIGNED":
             this.level = PriorityLevel.NONE;
             break;
@@ -50,8 +48,7 @@ public class Priority {
      * Returns true if a given string is a valid priority level.
      */
     public static boolean isValidPriority(String test) {
-        return test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_BLANK)
-                || test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_NONE)
+        return test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_NONE)
                 || test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_LOW)
                 || test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_MEDIUM)
                 || test.toUpperCase().equals(VALIDATION_STRING_PRIORITY_HIGH);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -53,6 +53,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_LECTURE = " " + PREFIX_TAG + VALID_TAG_LECTURE;
 
     public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "Do your homework!";
+    public static final String INVALID_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION;
     public static final String INVALID_PRIORITY_DESC = " " + PREFIX_PRIORITY + "Nope";
     public static final String INVALID_TASKDATE_DESC = " " + PREFIX_TASK_DATE + "2020/12/31";
     public static final String INVALID_TASKTIME_DESC = " " + PREFIX_TASK_TIME + "12 NOON";

--- a/src/test/java/seedu/address/logic/parser/AddDeadlineCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddDeadlineCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_LECTURE;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_PROJECT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRIORITY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASKDATE_DESC;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddDeadlineCommand;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Deadline;
+import seedu.address.model.task.Description;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.TaskDate;
 import seedu.address.model.task.Title;
@@ -109,7 +111,8 @@ public class AddDeadlineCommandParserTest {
                 + TASKDATE_DESC_PROJECT + TAG_DESC_PROJECT, Title.MESSAGE_CONSTRAINTS);
 
         // invalid description
-        // descriptions are optional as of v1.3
+        assertParseFailure(parser, TITLE_DESC_PROJECT + INVALID_DESCRIPTION_DESC + PRIORITY_DESC_PROJECT
+                + TASKDATE_DESC_PROJECT + TAG_DESC_PROJECT, Description.MESSAGE_CONSTRAINTS);
 
         // invalid priority
         assertParseFailure(parser, TITLE_DESC_PROJECT + DESCRIPTION_DESC_PROJECT + INVALID_PRIORITY_DESC

--- a/src/test/java/seedu/address/logic/parser/AddEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddEventCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_LECTURE;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_PROJECT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRIORITY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TASKDATE_DESC;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Description;
 import seedu.address.model.task.Event;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.TaskDate;
@@ -123,7 +125,8 @@ public class AddEventCommandParserTest {
                 + TASKDATE_DESC_PROJECT + TASKTIME_DESC_PROJECT + TAG_DESC_PROJECT, Title.MESSAGE_CONSTRAINTS);
 
         // invalid description
-        // descriptions are optional as of v1.3
+        assertParseFailure(parser, TITLE_DESC_PROJECT + INVALID_DESCRIPTION_DESC + PRIORITY_DESC_PROJECT
+                + TASKDATE_DESC_PROJECT + TASKTIME_DESC_PROJECT + TAG_DESC_PROJECT, Description.MESSAGE_CONSTRAINTS);
 
         // invalid priority
         assertParseFailure(parser, TITLE_DESC_PROJECT + DESCRIPTION_DESC_PROJECT + INVALID_PRIORITY_DESC

--- a/src/test/java/seedu/address/logic/parser/AddTodoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTodoCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_LECTURE;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_PROJECT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRIORITY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddTodoCommand;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Description;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.Title;
 import seedu.address.model.task.ToDo;
@@ -90,7 +92,8 @@ public class AddTodoCommandParserTest {
                 + TAG_DESC_PROJECT, Title.MESSAGE_CONSTRAINTS);
 
         // invalid description
-        // description is optional as of v1.3
+        assertParseFailure(parser, TITLE_DESC_PROJECT + INVALID_DESCRIPTION_DESC + PRIORITY_DESC_PROJECT
+                + TAG_DESC_PROJECT, Description.MESSAGE_CONSTRAINTS);
 
         // invalid priority
         assertParseFailure(parser, TITLE_DESC_PROJECT + DESCRIPTION_DESC_PROJECT + INVALID_PRIORITY_DESC

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.task.Title;
 
 public class ParserUtilTest {
     private static final String INVALID_TITLE = "Lecture$";
+    private static final String INVALID_DESCRIPTION = " ";
     private static final String INVALID_PRIORITY = "Higher";
     private static final String INVALID_TASKDATE = "20-12-31";
     private static final String INVALID_TASKTIME = "00:60";
@@ -84,6 +85,11 @@ public class ParserUtilTest {
     @Test
     public void parseDescription_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription((String) null));
+    }
+
+    @Test
+    public void parseDescription_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDescription(INVALID_DESCRIPTION));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/task/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/task/DescriptionTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.task;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -13,12 +14,19 @@ public class DescriptionTest {
     }
 
     @Test
+    public void constructor_invalidDescription_throwsIllegalArgumentException() {
+        String invalidDescription = "";
+        assertThrows(IllegalArgumentException.class, () -> new Description(invalidDescription));
+    }
+
+    @Test
     public void isValidDescription() {
         // null description
         assertThrows(NullPointerException.class, () -> Description.isValidDescription(null));
 
         // invalid descriptions
-        // No invalid descriptions
+        assertFalse(Description.isValidDescription("")); // empty string
+        assertFalse(Description.isValidDescription(" ")); // spaces only
 
         // valid descriptions
         assertTrue(Description.isValidDescription("Weekly lecture"));

--- a/src/test/java/seedu/address/model/task/PriorityTest.java
+++ b/src/test/java/seedu/address/model/task/PriorityTest.java
@@ -15,7 +15,7 @@ public class PriorityTest {
 
     @Test
     public void constructor_invalidPriorityLevel_throwsIllegalArgumentException() {
-        String invalidPriorityLevel = "Very High";
+        String invalidPriorityLevel = "";
         assertThrows(IllegalArgumentException.class, () -> new Priority(invalidPriorityLevel));
     }
 


### PR DESCRIPTION
- Description defaults to "No Description" if description tag is not used.
- Disallow use of `/time` command tag in `todo` and `deadline`, and `/date` command tag in `todo`. 